### PR TITLE
fix usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ And include in your project by creating a `preact.config.js`
 const preactCliPostCSS = require('preact-cli-postcss');
 
 export default function (config, env, helpers) {
-	preactCliPostCSS(helpers);
+	preactCliPostCSS(config, helpers);
 }
 ```
 


### PR DESCRIPTION
Shows that end users need to pass `config` as first argument of the plugin